### PR TITLE
update python-tidal to v0.8.5

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,7 +84,6 @@ def main(args):
         config.read([args_parsed.ini])
         try:
             session.load_oauth_session(
-                config['session']['id'],
                 config['session']['token_type'],
                 config['session']['access_token'],
                 config['session'].get('refresh_token', None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/tamland/python-tidal.git@0.6.x
+git+https://github.com/tamland/python-tidal.git@v0.8.5


### PR DESCRIPTION
These changes made `tidal_backup_favorites` work for me again.

- tag 0.6 for `python-tidal` went away
- updated `python-tidal` to latest version, i.e., 0.8.5
- adapted code to interface changes of `python-tidal`

Thanks for considering.